### PR TITLE
fix: correct gaussian_weights normalization and y-axis symmetry

### DIFF
--- a/tiled_diffusion.py
+++ b/tiled_diffusion.py
@@ -819,9 +819,9 @@ def gaussian_weights(tile_w:int, tile_h:int) -> Tensor:
     This generates gaussian weights to smooth the noise of each tile.
     This is critical for this method to work.
     '''
-    f = lambda x, midpoint, var=0.01: exp(-(x-midpoint)*(x-midpoint) / (tile_w*tile_w) / (2*var)) / sqrt(2*pi*var)
-    x_probs = [f(x, (tile_w - 1) / 2) for x in range(tile_w)]   # -1 because index goes from 0 to latent_width - 1
-    y_probs = [f(y,  tile_h      / 2) for y in range(tile_h)]
+    f = lambda x, midpoint, tile_dim, var=0.01: exp(-(x-midpoint)*(x-midpoint) / (2*var*tile_dim*tile_dim)) / (sqrt(2*pi*var)*tile_dim)
+    x_probs = [f(x, (tile_w - 1) / 2, tile_w) for x in range(tile_w)]   # -1 because index goes from 0 to latent_width - 1
+    y_probs = [f(y, (tile_h - 1) / 2, tile_h) for y in range(tile_h)]   # -1 because index goes from 0 to latent_height - 1
 
     w = np.outer(y_probs, x_probs)
     return torch.from_numpy(w).to(devices.device, dtype=torch.float32)


### PR DESCRIPTION
## What's wrong

The `gaussian_weights` function has three bugs that produce incorrect blending weights for tiled diffusion:

1. **Wrong variance scaling for y-axis**: The lambda hardcodes `tile_w*tile_w` in the denominator, so `y_probs` uses the wrong tile dimension when tiles aren't square (e.g. 32×8 tiles get weights computed as if they're 32×32).
2. **Off-by-one in y midpoint**: The x midpoint correctly uses `(tile_w - 1) / 2` (because indices go 0 to n-1), but the y midpoint uses `tile_h / 2` instead of `(tile_h - 1) / 2`. This breaks the symmetry of the gaussian — verified below.
3. **Unnormalized gaussian**: The divisor is `sqrt(2*pi*var)` instead of `sqrt(2*pi*var)*tile_dim`, so the distribution sums to ~25-32 instead of ~1.0.

## What this does

Passes `tile_dim` as an explicit parameter to the lambda so each axis uses its own dimension. Fixes the y midpoint to match the x midpoint. Adds the missing `tile_dim` factor to the normalization divisor.

## How to verify

The fix is purely mathematical. Running a quick symmetry check confirms the old code is asymmetric on the y-axis while the fixed code is symmetric:

```python
from numpy import pi, exp, sqrt

# Old: y_probs for tile_h=8, midpoint=4.0 (wrong)
f_old = lambda x, mid, var=0.01: exp(-(x-mid)**2 / (32**2) / (2*var)) / sqrt(2*pi*var)
old = [f_old(y, 4.0) for y in range(8)]
print(old[0], old[-1])  # 1.826 vs 2.571 — NOT symmetric

# New: y_probs for tile_h=8, midpoint=3.5 (correct)
f_new = lambda x, mid, d, var=0.01: exp(-(x-mid)**2 / (2*var*d*d)) / (sqrt(2*pi*var)*d)
new = [f_new(y, 3.5, 8) for y in range(8)]
print(new[0], new[-1])  # symmetric ✓
```

Fixes #5
